### PR TITLE
Version 0.4.7

### DIFF
--- a/package/0_Common/Scripts/Source/User/RealHandcuffs/Installer.psc
+++ b/package/0_Common/Scripts/Source/User/RealHandcuffs/Installer.psc
@@ -23,7 +23,7 @@ String Property UpdatePendingState = "UpdatePending" AutoReadOnly ; 'update pend
 String Property DisabledState      = "Disabled"      AutoReadOnly ; 'disabled' state, will never change
 
 String Property StateVersion       = "V1"            AutoReadOnly ; internal state version string, will change when a new version requires different install/uninstall steps
-String Property DetailedVersion    = "0.4.6"         AutoReadOnly ; user version string, will change with every new version
+String Property DetailedVersion    = "0.4.7"         AutoReadOnly ; user version string, will change with every new version
 
 String Property InstalledDetailedVersion Auto ; currently installed detailed version
 String Property InstalledEdition Auto         ; currently installed edition

--- a/package/0_Common/Scripts/Source/User/RealHandcuffs/PrisonerMat.psc
+++ b/package/0_Common/Scripts/Source/User/RealHandcuffs/PrisonerMat.psc
@@ -356,7 +356,7 @@ Function AssignActor(WorkshopNPCScript newActor = None)
         EndIf
     EndIf
     assignedActor = newActor
-    If (assignedActor != None)
+    If (assignedActor != None && assignedActor != _assignedActor)
         _assignedActor = assignedActor
         assignedActor.SetLinkedRef(Self, Library.Resources.PrisonerMatLink)
         Library.PrisonerMatActors.AddRef(assignedActor)

--- a/package/0_Common/Scripts/Source/User/RealHandcuffs/PrisonerMatWorkshopObjectScript.psc
+++ b/package/0_Common/Scripts/Source/User/RealHandcuffs/PrisonerMatWorkshopObjectScript.psc
@@ -30,7 +30,7 @@ Function HandleDeletion()
     Parent.HandleDeletion()
 EndFunction
 
-Function AssignActor(WorkshopNPCScript newActor = None)
+Function AssignActorCustom(WorkshopNPCScript newActor)
     PrisonerMat.AssignActor(newActor)
-    Parent.AssignActor(newActor)
+    Parent.AssignActorCustom(newActor)
 EndFunction

--- a/package/FOMod/info.xml
+++ b/package/FOMod/info.xml
@@ -1,7 +1,7 @@
 <fomod>
   <Name>Real Handcuffs</Name>
   <Author>Kharos</Author>
-  <Version>0.4.6</Version>
+  <Version>0.4.7</Version>
   <Description>Converts handcuffs found throughout the Commonwealth to a equippable armor item that can be used to bind both the player and NPCs. Now with real shock collars, too!</Description>
   <Website>https://www.loverslab.com/files/file/8485-real-handcuffs/</Website>
 </fomod>

--- a/package/changelog.txt
+++ b/package/changelog.txt
@@ -439,3 +439,9 @@ various fixes and improvements
 - increase chance that captives are still in place when returning to a settlement
 - DD compatibility plugin: remove neck slots usage from institute leg cuffs (bug in DD causing compatibility issues with shock collar)
 - add suport for canary save file monitor
+
+Version 0.4.7
+=============
+compatibility with WorkshopFramework 2.0.0
+- change function used to detect assignment to prisoner mats to be compatible with WorkshopFramework 2
+- some tweaks to code that tries to keep captives in place when returning to a settlement


### PR DESCRIPTION
Override AssignActorCustom instead of AssignActor in PrisonerMatWorkshopObjectScript.
Also tweak code that tries to keep prisoners in place when returning to settlement.