### PR TITLE
changes to improve compatibility with AAF

### DIFF
--- a/package/0_Common/Scripts/Source/User/RealHandcuffs/Installer.psc
+++ b/package/0_Common/Scripts/Source/User/RealHandcuffs/Installer.psc
@@ -23,7 +23,7 @@ String Property UpdatePendingState = "UpdatePending" AutoReadOnly ; 'update pend
 String Property DisabledState      = "Disabled"      AutoReadOnly ; 'disabled' state, will never change
 
 String Property StateVersion       = "V1"            AutoReadOnly ; internal state version string, will change when a new version requires different install/uninstall steps
-String Property DetailedVersion    = "0.4.8 alpha 2" AutoReadOnly ; user version string, will change with every new version
+String Property DetailedVersion    = "0.4.8 alpha 3" AutoReadOnly ; user version string, will change with every new version
 
 String Property InstalledDetailedVersion Auto ; currently installed detailed version
 String Property InstalledEdition Auto         ; currently installed edition

--- a/package/0_Common/Scripts/Source/User/RealHandcuffs/Installer.psc
+++ b/package/0_Common/Scripts/Source/User/RealHandcuffs/Installer.psc
@@ -23,7 +23,7 @@ String Property UpdatePendingState = "UpdatePending" AutoReadOnly ; 'update pend
 String Property DisabledState      = "Disabled"      AutoReadOnly ; 'disabled' state, will never change
 
 String Property StateVersion       = "V1"            AutoReadOnly ; internal state version string, will change when a new version requires different install/uninstall steps
-String Property DetailedVersion    = "0.4.7"         AutoReadOnly ; user version string, will change with every new version
+String Property DetailedVersion    = "0.4.8 alpha 1" AutoReadOnly ; user version string, will change with every new version
 
 String Property InstalledDetailedVersion Auto ; currently installed detailed version
 String Property InstalledEdition Auto         ; currently installed edition

--- a/package/0_Common/Scripts/Source/User/RealHandcuffs/Installer.psc
+++ b/package/0_Common/Scripts/Source/User/RealHandcuffs/Installer.psc
@@ -23,7 +23,7 @@ String Property UpdatePendingState = "UpdatePending" AutoReadOnly ; 'update pend
 String Property DisabledState      = "Disabled"      AutoReadOnly ; 'disabled' state, will never change
 
 String Property StateVersion       = "V1"            AutoReadOnly ; internal state version string, will change when a new version requires different install/uninstall steps
-String Property DetailedVersion    = "0.4.8 alpha 1" AutoReadOnly ; user version string, will change with every new version
+String Property DetailedVersion    = "0.4.8 alpha 2" AutoReadOnly ; user version string, will change with every new version
 
 String Property InstalledDetailedVersion Auto ; currently installed detailed version
 String Property InstalledEdition Auto         ; currently installed edition
@@ -296,17 +296,28 @@ State V1
             If (token != None && !token.CheckConsistency(restrainedNpc))
                 token = Library.TryGetActorToken(restrainedNpc)
             EndIf
-            If (token == None || restrainedNpc.IsDead() || token.Restraints == None || token.Restraints.Length == 0) ; fallback code, not expected
+            If (token == None || restrainedNpc.IsDead() || restrainedNpc.IsDeleted() || token.Restraints == None || token.Restraints.Length == 0)
                 String reason
+                Bool warning = true
                 If (token == None)
                     reason = "no token"
                 ElseIf (restrainedNpc.IsDead())
                     reason = "dead"
+                ElseIf (restrainedNpc.IsDeleted())
+                    reason = "deleted"
+                    warning = false
                 Else
                     reason = "no restraints"
                 EndIf
+                If (token != None)
+                    token.Uninitialize()
+                EndIf
                 restrained.RemoveRef(restrainedNpc)
-                RealHandcuffs:Log.Warning("Removed from restrained NPCs [" + restrained.GetCount() + "]: " + RealHandcuffs:Log.FormIdAsString(restrainedNpc) + " " + restrainedNpc.GetDisplayName() + " (" + reason + ")", Library.Settings)
+                If (warning)
+                    RealHandcuffs:Log.Warning("Removed from restrained NPCs [" + restrained.GetCount() + "]: " + RealHandcuffs:Log.FormIdAsString(restrainedNpc) + " " + restrainedNpc.GetDisplayName() + " (" + reason + ")", Library.Settings)
+                Else
+                    RealHandcuffs:Log.Info("Removed from restrained NPCs [" + restrained.GetCount() + "]: " + RealHandcuffs:Log.FormIdAsString(restrainedNpc) + " " + restrainedNpc.GetDisplayName() + " (" + reason +  ")", Library.Settings)
+                EndIf
             Else
                 token.RefreshOnGameLoad(true)
                 token.RefreshEventRegistrations()
@@ -424,17 +435,28 @@ State V1
             If (token != None && !token.CheckConsistency(restrainedNpc))
                 token = Library.TryGetActorToken(restrainedNpc)
             EndIf
-            If (token == None || restrainedNpc.IsDead() || token.Restraints == None || token.Restraints.Length == 0) ; fallback code, not expected
+            If (token == None || restrainedNpc.IsDead() || restrainedNpc.IsDeleted() || token.Restraints == None || token.Restraints.Length == 0)
                 String reason
+                Bool warning = true
                 If (token == None)
                     reason = "no token"
                 ElseIf (restrainedNpc.IsDead())
                     reason = "dead"
+                ElseIf (restrainedNpc.IsDeleted())
+                    reason = "deleted"
+                    warning = false
                 Else
                     reason = "no restraints"
                 EndIf
+                If (token != None)
+                    token.Uninitialize()
+                EndIf
                 restrained.RemoveRef(restrainedNpc)
-                RealHandcuffs:Log.Warning("Removed from restrained NPCs [" + restrained.GetCount() + "]: " + RealHandcuffs:Log.FormIdAsString(restrainedNpc) + " " + restrainedNpc.GetDisplayName() + " (" + reason + ")", Library.Settings)
+                If (warning)
+                    RealHandcuffs:Log.Warning("Removed from restrained NPCs [" + restrained.GetCount() + "]: " + RealHandcuffs:Log.FormIdAsString(restrainedNpc) + " " + restrainedNpc.GetDisplayName() + " (" + reason + ")", Library.Settings)
+                Else
+                    RealHandcuffs:Log.Info("Removed from restrained NPCs [" + restrained.GetCount() + "]: " + RealHandcuffs:Log.FormIdAsString(restrainedNpc) + " " + restrainedNpc.GetDisplayName() + " (" + reason + ")", Library.Settings)
+                EndIf
             Else
                 token.RefreshOnGameLoad(false)
                 index += 1

--- a/package/0_Common/Scripts/Source/User/RealHandcuffs/Installer.psc
+++ b/package/0_Common/Scripts/Source/User/RealHandcuffs/Installer.psc
@@ -23,7 +23,7 @@ String Property UpdatePendingState = "UpdatePending" AutoReadOnly ; 'update pend
 String Property DisabledState      = "Disabled"      AutoReadOnly ; 'disabled' state, will never change
 
 String Property StateVersion       = "V1"            AutoReadOnly ; internal state version string, will change when a new version requires different install/uninstall steps
-String Property DetailedVersion    = "0.4.8 alpha 3" AutoReadOnly ; user version string, will change with every new version
+String Property DetailedVersion    = "0.4.8"         AutoReadOnly ; user version string, will change with every new version
 
 String Property InstalledDetailedVersion Auto ; currently installed detailed version
 String Property InstalledEdition Auto         ; currently installed edition

--- a/package/0_Common/Scripts/Source/User/RealHandcuffs/NpcToken.psc
+++ b/package/0_Common/Scripts/Source/User/RealHandcuffs/NpcToken.psc
@@ -71,6 +71,9 @@ Function Initialize(Actor myTarget)
         RegisterForCustomEvent(WorkshopParent, "WorkshopActorUnassigned")
         StartTimer(2, UpdateWorkshopSandboxLocation)
     EndIf
+    If (Library.SoftDependencies.AdvancedAnimationFrameworkAvailable && myTarget.GetActorBase() == Library.SoftDependencies.AAF_Doppelganger)
+        myTarget.AddKeyword(NoPackage) ; permanently add the NoPackage keyword to AAF doppelganger
+    EndIf
 EndFunction
 
 ;
@@ -189,6 +192,9 @@ Function RefreshOnGameLoad(Bool upgrade)
             WorkshopNpcScript workshopNpc = Target as WorkshopNpcScript
             If (workshopNpc != None)
                 StartTimer(2, UpdateWorkshopSandboxLocation)
+            EndIf
+            If (Library.SoftDependencies.AdvancedAnimationFrameworkAvailable && Target.GetActorBase() == Library.SoftDependencies.AAF_Doppelganger)
+                Target.AddKeyword(NoPackage) ; permanently add the NoPackage keyword to AAF doppelganger
             EndIf
         EndIf
     EndIf

--- a/package/0_Common/Scripts/Source/User/RealHandcuffs/NpcToken.psc
+++ b/package/0_Common/Scripts/Source/User/RealHandcuffs/NpcToken.psc
@@ -64,6 +64,7 @@ Function Initialize(Actor myTarget)
     RegisterForRemoteEvent(myTarget, "OnCommandModeCompleteCommand")
     RegisterForRemoteEvent(myTarget, "OnCommandModeExit")
     RegisterForRemoteEvent(myTarget, "OnDeath") 
+    RegisterForRemoteEvent(myTarget, "OnUnload") 
     RegisterForRemoteEvent(myTarget, "OnWorkshopNPCTransfer")
     WorkshopNpcScript workshopNpc = myTarget as WorkshopNpcScript
     If (workshopNpc != None)
@@ -102,6 +103,7 @@ Function Uninitialize()
         UnregisterForRemoteEvent(Target, "OnCommandModeCompleteCommand")
         UnregisterForRemoteEvent(Target, "OnCommandModeExit")
         UnregisterForRemoteEvent(Target, "OnDeath")
+        UnregisterForRemoteEvent(Target, "OnUnload")
         UnregisterForRemoteEvent(Target, "OnWorkshopNPCTransfer")
         If (Library.RestrainedNpcs.Find(Target) >= 0)
             Library.RestrainedNpcs.RemoveRef(Target)
@@ -220,6 +222,7 @@ Function RefreshEventRegistrations()
     UnregisterForRemoteEvent(Target, "OnCommandModeCompleteCommand")
     UnregisterForRemoteEvent(Target, "OnCommandModeExit")
     UnregisterForRemoteEvent(Target, "OnDeath")
+    UnregisterForRemoteEvent(Target, "OnUnload")
     UnregisterForRemoteEvent(Target, "OnWorkshopNPCTransfer")
     Parent.RefreshEventRegistrations()
     RegisterForRemoteEvent(Target, "OnCommandModeEnter")
@@ -227,6 +230,7 @@ Function RefreshEventRegistrations()
     RegisterForRemoteEvent(Target, "OnCommandModeCompleteCommand")
     RegisterForRemoteEvent(Target, "OnCommandModeExit")
     RegisterForRemoteEvent(Target, "OnDeath") 
+    RegisterForRemoteEvent(Target, "OnUnload") 
     RegisterForRemoteEvent(Target, "OnWorkshopNPCTransfer")
     If (workshopNpc != None)
         RegisterForCustomEvent(WorkshopParent, "WorkshopActorAssignedToWork")
@@ -511,6 +515,20 @@ Event Actor.OnDeath(Actor sender, Actor akKiller)
     Uninitialize()
     If (Library.Settings.InfoLoggingEnabled)
         RealHandcuffs:Log.Info("Destroyed token for " + RealHandcuffs:Log.FormIdAsString(oldTarget) + " " + oldTarget.GetDisplayName(), Library.Settings)
+    EndIf
+EndEvent
+
+;
+; Event handler for unload of the actor.
+;
+Event ObjectReference.OnUnload(ObjectReference sender)
+    ; destoy the token if actor is deleted
+    Actor oldTarget = Target
+    If (oldTarget.IsDeleted())
+        Uninitialize()
+        If (Library.Settings.InfoLoggingEnabled)
+            RealHandcuffs:Log.Info("Destroyed token for " + RealHandcuffs:Log.FormIdAsString(oldTarget) + " " + oldTarget.GetDisplayName(), Library.Settings)
+        EndIf
     EndIf
 EndEvent
 

--- a/package/0_Common/Scripts/Source/User/RealHandcuffs/NpcToken.psc
+++ b/package/0_Common/Scripts/Source/User/RealHandcuffs/NpcToken.psc
@@ -1039,11 +1039,10 @@ Function FixWeaponDrawn()
         StartTimer(3, WaitForConsciousness)
     Else
         ; For some unknown reason NPCs sometimes get stuck with drawn weapon animations.
-        ; It is hard to find a reliable way to solve this, currently the best way is to initialize the MT graph
+        ; It is hard to find a reliable way to solve this, currently the best way is to (re)initialize the MT graph.
         ; Only do this if we have not done it in the last thirty seconds
-        Utility.Wait(2) ; give HandleBoundHandsPackageChanged a chance to fix the situation before forcing bleedout
         Float realTime = Utility.GetCurrentRealTime()
-        If (Target.IsWeaponDrawn() && (_lastInitializeMtGraphTimestamp == 0 || (realTime - _lastInitializeMtGraphTimestamp) > 30))
+        If ((_lastInitializeMtGraphTimestamp == 0 || (realTime - _lastInitializeMtGraphTimestamp) > 30) && !Library.SoftDependencies.IsInAafScene(Target))
             _lastInitializeMtGraphTimestamp = realTime
             CancelTimer(WaitForConsciousness)
             CancelTimer(StartCheckingWeapon)
@@ -1096,7 +1095,7 @@ Function HandleBoundHandsPackageChanged()
         Float realTime = Utility.GetCurrentRealTime()
         If ((realTime - _lastKickAiTimestamp) > 1 && (currentPackage as RealHandcuffs:BoundHandsPackage) == None)
             ; moved away from a 'bound hands' package
-            If (!Target.HasKeyword(NoPackage) && Target.HasKeyword(BoundHands) && Library.RestrainedNpcs.Find(Target) >= 0)
+            If (!Target.HasKeyword(NoPackage) && Target.HasKeyword(BoundHands) && Library.RestrainedNpcs.Find(Target) >= 0 && !Library.SoftDependencies.IsInAafScene(Target))
                 ; but we expect such a package to be active
                 _lastKickAiTimestamp = realTime
                 If (Library.Settings.InfoLoggingEnabled)

--- a/package/0_Common/Scripts/Source/User/RealHandcuffs/PlayerToken.psc
+++ b/package/0_Common/Scripts/Source/User/RealHandcuffs/PlayerToken.psc
@@ -576,7 +576,7 @@ Event OnKeyDown(int keyCode)
         ; ignore hotkey when menu is active
         Return
     EndIf
-    If (Library.SoftDependencies.AdvancedAnimationFrameworkAvailable && Target.HasKeyword(Library.SoftDependencies.AAF_ActorBusy))
+    If (Library.SoftDependencies.IsInAafScene(Target))
         ; ignore hotkey when running AAF animation
         Return
     EndIf

--- a/package/0_Common/Scripts/Source/User/RealHandcuffs/PrisonerMat.psc
+++ b/package/0_Common/Scripts/Source/User/RealHandcuffs/PrisonerMat.psc
@@ -99,6 +99,9 @@ EndFunction
 ; Override: Unregister the registered actor from the marker.
 ;
 Function Unregister(Actor akActor)
+    If (akActor == _assignedActor)
+        AssignActor(None)
+    EndIf
     Bool isRegistered = (akActor == GetRegisteredActor())
     Parent.Unregister(akActor)
     If (isRegistered )

--- a/package/0_Common/Scripts/Source/User/RealHandcuffs/SoftDependencies.psc
+++ b/package/0_Common/Scripts/Source/User/RealHandcuffs/SoftDependencies.psc
@@ -138,6 +138,7 @@ EndGroup
 ;
 Group AdvancedAnimationFramework
     Keyword Property AAF_ActorBusy Auto
+    ActorBase Property AAF_Doppelganger Auto
 EndGroup
 
 ;
@@ -362,11 +363,14 @@ Bool Function GetAdvancedAnimationFrameworkForms()
     Quest aafMainQuest = Game.GetFormFromFile(0x000F99, AdvancedAnimationFramework) as Quest
     If (aafMainQuest == None)
         AAF_ActorBusy = None
+        AAF_Doppelganger = None
         Return False
     EndIf
     ScriptObject aafApi = aafMainQuest.CastAs("AAF:AAF_API")
     AAF_ActorBusy = aafApi.GetPropertyValue("AAF_ActorBusy") as Keyword
-    Return AAF_ActorBusy != None
+    ScriptObject aafMainQuestScript = aafMainQuest.CastAs("AAF:AAF_MainQuestScript")
+    AAF_Doppelganger = aafMainQuestScript.GetPropertyValue("AAF_Doppelganger") as ActorBase
+    Return aafApi != None && AAF_ActorBusy != None && aafMainQuestScript != None && AAF_Doppelganger != None
 EndFunction
 
 ;

--- a/package/0_Common/Scripts/Source/User/RealHandcuffs/SoftDependencies.psc
+++ b/package/0_Common/Scripts/Source/User/RealHandcuffs/SoftDependencies.psc
@@ -497,7 +497,14 @@ Bool Function IsDeviousDevicesGagged(Actor target)
 EndFunction
 
 ;
-; Check if a actor is a slave.
+; Check if an actor is in a AAF scene.
+;
+Bool Function IsInAafScene(Actor target)
+    Return AdvancedAnimationFrameworkAvailable && target.HasKeyword(AAF_ActorBusy)
+EndFunction
+
+;
+; Check if an actor is a slave.
 ;
 Bool Function IsSlave(Actor target)
     Return JustBusinessAvailable && target.IsInFaction(JBSlaveFaction)

--- a/package/FOMod/info.xml
+++ b/package/FOMod/info.xml
@@ -1,7 +1,7 @@
 <fomod>
   <Name>Real Handcuffs</Name>
   <Author>Kharos</Author>
-  <Version>0.4.7</Version>
+  <Version>$VERSION</Version>
   <Description>Converts handcuffs found throughout the Commonwealth to a equippable armor item that can be used to bind both the player and NPCs. Now with real shock collars, too!</Description>
   <Website>https://www.loverslab.com/files/file/8485-real-handcuffs/</Website>
 </fomod>

--- a/package/changelog.txt
+++ b/package/changelog.txt
@@ -449,8 +449,9 @@ compatibility with WorkshopFramework 2.0.0
 Version 0.4.8
 =============
 changes to improve compatibility with AAF
-- use special idle action instead of bleedout to force NPCs to stow weapons
+- use special idle action instead of bleedout when forcing NPCs to stow weapons
 - improve general handling of actors who are part of AAF scenes
-- put RH_NoPackage keyword on AAF doppelganger to prevent application of RH packages even outside of scene
-- make sure deleted NPCs (e.g. old AFF doppelganger) are cleaned from the RefCollectionAlias on game load (there is no event when actors are deleted)
+- make sure no packages are applied to AAF doppelganger (using RH_NoPackage)
+- check if NPCs are delete in OnUnload event and remove them from the managed NPCs if they are
+- check for deleted NPCs when loading the game and remove them from the managed NPCs (there is no event when actors are deleted)
 - fix: unassign companions who are assigned to prisoner mat when told to follow the player again

--- a/package/changelog.txt
+++ b/package/changelog.txt
@@ -446,10 +446,11 @@ compatibility with WorkshopFramework 2.0.0
 - change function used to detect assignment to prisoner mats to be compatible with WorkshopFramework 2.0.0
 - some tweaks to code that tries to keep captives in place when returning to a settlement
 
-Version 0.4.8 (PRERELEASE)
-==========================
-TODO one-line summary of changes
+Version 0.4.8
+=============
+changes to improve compatibility with AAF
 - use special idle action instead of bleedout to force NPCs to stow weapons
+- improve general handling of actors who are part of AAF scenes
+- put RH_NoPackage keyword on AAF doppelganger to prevent application of RH packages even outside of scene
+- make sure deleted NPCs (e.g. old AFF doppelganger) are cleaned from the RefCollectionAlias on game load (there is no event when actors are deleted)
 - fix: unassign companions who are assigned to prisoner mat when told to follow the player again
-- do not apply packages to AAF player doppelganger (by putting RH_NoPackage keyword on doppelganger)
-- make sure deleted NPCs (e.g. old AFF play doppelganger) are cleaned from the RefCollectionAlias on game load

--- a/package/changelog.txt
+++ b/package/changelog.txt
@@ -449,4 +449,7 @@ compatibility with WorkshopFramework 2.0.0
 Version 0.4.8 (PRERELEASE)
 ==========================
 TODO one-line summary of changes
-- do not apply packages to AAF player doppelganger 
+- use special idle action instead of bleedout to force NPCs to stow weapons
+- fix: unassign companions who are assigned to prisoner mat when told to follow the player again
+- do not apply packages to AAF player doppelganger (by putting RH_NoPackage keyword on doppelganger)
+- make sure deleted NPCs (e.g. old AFF play doppelganger) are cleaned from the RefCollectionAlias on game load

--- a/package/changelog.txt
+++ b/package/changelog.txt
@@ -443,5 +443,10 @@ various fixes and improvements
 Version 0.4.7
 =============
 compatibility with WorkshopFramework 2.0.0
-- change function used to detect assignment to prisoner mats to be compatible with WorkshopFramework 2
+- change function used to detect assignment to prisoner mats to be compatible with WorkshopFramework 2.0.0
 - some tweaks to code that tries to keep captives in place when returning to a settlement
+
+Version 0.4.8 (PRERELEASE)
+==========================
+TODO one-line summary of changes
+- do not apply packages to AAF player doppelganger 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -65,7 +65,15 @@ if [[ "$QUIET" == "" ]]
 then
   echo Copying files.
 fi
-cp -r package build
+cp -r -p package build
+VERSION=$(cat build/package/0_Common/Scripts/Source/User/RealHandcuffs/Installer.psc | sed -nr 's/^\s*String\s+Property\s+DetailedVersion\s*=\s*"([^"]+)"\s+AutoReadOnly\s*(;.*)$/\1/p')
+if [[ "$QUIET" == "" ]]
+then
+  echo "  Version: $VERSION"
+fi
+mv build/package/FOMod/info.xml build/package/FOMod/info.xml.old
+VERSION=$VERSION envsubst < build/package/FOMod/info.xml.old > build/package/FOMod/info.xml
+rm build/package/FOMod/info.xml.old
 
 # set up function to pack assets
 # $1: folder (must be folder in build/package, without the "build" part
@@ -134,7 +142,6 @@ if [[ "$QUIET" == "" ]]
 then
  echo "Creating archive:"
 fi
-VERSION=$(cat build/package/FOMod/info.xml | sed -nr 's/.*<Version>([^<]+)<\/Version>.*/\1/p')
 "$TOOL_7ZIP" a -t7z -mx=9 -mmt=off "build\RealHandcuffs.$VERSION.7z" ".\build\package\*" > /dev/null
 if [[ "$QUIET" == "" ]]
 then


### PR DESCRIPTION
- use special idle action instead of bleedout when forcing NPCs to stow weapons
- improve general handling of actors who are part of AAF scenes
- make sure no packages are applied to AAF doppelganger (using RH_NoPackage)
- check if NPCs are delete in OnUnload event and remove them from the managed NPCs if they are
- check for deleted NPCs when loading the game and remove them from the managed NPCs (there is no event when actors are deleted)
- fix: unassign companions who are assigned to prisoner mat when told to follow the player again